### PR TITLE
change default endpoint to https://api.dreamdata.cloud

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,28 +4,28 @@ jobs:
   build-golatest:
     docker:
       - image: circleci/golang
-    working_directory: /go/src/github.com/segmentio/analytics-go
+    working_directory: /go/src/github.com/dreamdata-io/analytics-go
     steps:
       - checkout
       - run: make ci
   build-go113:
     docker:
       - image: circleci/golang:1.13
-    working_directory: /go/src/github.com/segmentio/analytics-go
+    working_directory: /go/src/github.com/dreamdata-io/analytics-go
     steps:
       - checkout
       - run: make ci
   build-go112:
     docker:
       - image: circleci/golang:1.12
-    working_directory: /go/src/github.com/segmentio/analytics-go
+    working_directory: /go/src/github.com/dreamdata-io/analytics-go
     steps:
       - checkout
       - run: make ci
   build-go111:
     docker:
       - image: circleci/golang:1.11
-    working_directory: /go/src/github.com/segmentio/analytics-go
+    working_directory: /go/src/github.com/dreamdata-io/analytics-go
     steps:
       - checkout
       - run: make ci

--- a/Readme.md
+++ b/Readme.md
@@ -40,6 +40,9 @@ func main() {
 }
 ```
 
-## License
+## Disclaimer
+Even though this repo is forked from [Segment repo](https://github.com/segmentio/analytics-go), it might not be compatible with Segment's latest version. We never want anyone to use this fork to attempt to talk to Segment, by mistake.
 
+
+## License
 The library is released under the [MIT license](License.md).

--- a/Readme.md
+++ b/Readme.md
@@ -21,6 +21,7 @@ package main
 
 import (
     "os"
+	"golang.org/x/sync/errgroup"
 
     "github.com/dreamdata-io/analytics-go"
 )
@@ -29,11 +30,47 @@ func main() {
     // Instantiates a client to send messages to the dreamdata API.
     client := analytics.New(os.Getenv("DREAMDATA_WRITE_KEY"))
 
-    // Enqueues a track event that will be sent asynchronously.
-    client.Enqueue(analytics.Track{
-        UserId: "test-user",
-        Event:  "test-snippet",
-    })
+	errGroup := new(errgroup.Group)
+
+	errGroup.Go(c.Enqueue(analytics.Identify{
+		UserId: "019mr8mf4r",
+		Traits: map[string]interface{}{
+			"email": "user@dreamdata.io",
+			"name":  "user",
+			"age":   25,
+		},
+	}))
+
+	errGroup.Go(c.Enqueue(analytics.Track{
+		UserId: "019mr8mf4r",
+		Event:  "Song Played",
+		Properties: map[string]interface{}{
+			"name":   "My song",
+			"artist": "My artist",
+		},
+	}))
+
+	errGroup(c.Enqueue(analytics.Identify{
+		UserId: "971mj8mk7p",
+		Traits: map[string]interface{}{
+			"email": "user2@dreamdata.io",
+			"name":  "user2",
+			"age":   26,
+		},
+	}))
+
+	errGroup(c.Enqueue(analytics.Track{
+		UserId: "971mj8mk7p",
+		Event:  "Song Played",
+		Properties: map[string]interface{}{
+			"name":   "My song",
+			"artist": "My artist",
+		},
+	}))
+
+	if err := errGroup.Wait(); err == nil {
+		fmt.Printf("Successfully enqueued messages")
+	}
 
     // Flushes any queued messages and closes the client.
     client.Close()

--- a/Readme.md
+++ b/Readme.md
@@ -30,46 +30,50 @@ func main() {
     // Instantiates a client to send messages to the dreamdata API.
     client := analytics.New(os.Getenv("DREAMDATA_WRITE_KEY"))
 
-	errGroup := new(errgroup.Group)
+	var err error
 
-	errGroup.Go(c.Enqueue(analytics.Identify{
+	err = c.Enqueue(analytics.Identify{
 		UserId: "019mr8mf4r",
-		Traits: map[string]interface{}{
-			"email": "user@dreamdata.io",
-			"name":  "user",
-			"age":   25,
-		},
-	}))
+		Traits: analytics.NewTraits().
+			SetEmail("user@dreamdata.io").
+			SetName("user").
+			SetAge(25),
+	})
+	if err != nil {
+		// do something with your err
+	}
 
-	errGroup.Go(c.Enqueue(analytics.Track{
+	err = c.Enqueue(analytics.Track{
 		UserId: "019mr8mf4r",
 		Event:  "Song Played",
-		Properties: map[string]interface{}{
-			"name":   "My song",
-			"artist": "My artist",
-		},
-	}))
+		Properties: analytics.NewProperties().
+			SetName("My song").
+			Set("artist", "My artist"),
+	})
+	if err != nil {
+		// do something with your err
+	}
 
-	errGroup(c.Enqueue(analytics.Identify{
+	err = c.Enqueue(analytics.Identify{
 		UserId: "971mj8mk7p",
-		Traits: map[string]interface{}{
-			"email": "user2@dreamdata.io",
-			"name":  "user2",
-			"age":   26,
-		},
-	}))
+		Traits: analytics.NewTraits().
+			SetEmail("user2@dreamdata.io").
+			SetName("user2").
+			SetAge(26),
+	})
+	if err != nil {
+		// do something with your err
+	}
 
-	errGroup(c.Enqueue(analytics.Track{
+	err = c.Enqueue(analytics.Track{
 		UserId: "971mj8mk7p",
 		Event:  "Song Played",
-		Properties: map[string]interface{}{
-			"name":   "My song",
-			"artist": "My artist",
-		},
-	}))
-
-	if err := errGroup.Wait(); err == nil {
-		fmt.Printf("Successfully enqueued messages")
+		Properties: analytics.NewProperties().
+			SetName("My song").
+			Set("artist", "My artist"),
+	})
+	if err != nil {
+		// do something with your err
 	}
 
     // Flushes any queued messages and closes the client.

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
-# analytics-go [![Circle CI](https://circleci.com/gh/segmentio/analytics-go/tree/v3.0.svg?style=shield)](https://circleci.com/gh/segmentio/analytics-go/tree/v3.0) [![go-doc](https://godoc.org/github.com/segmentio/analytics-go?status.svg)](https://godoc.org/github.com/segmentio/analytics-go)
+# analytics-go
 
-Segment analytics client for Go.
+Dreamdata analytics client for Go.
 
 ## Installation
 
@@ -11,18 +11,8 @@ versions of the library.
 
 To install it in the GOPATH:
 ```
-go get https://github.com/segmentio/analytics-go
+go get https://github.com/dreamdata-io/analytics-go
 ```
-
-## Documentation
-
-The links bellow should provide all the documentation needed to make the best
-use of the library and the Segment API:
-
-- [Documentation](https://segment.com/docs/libraries/go/)
-- [godoc](https://godoc.org/gopkg.in/segmentio/analytics-go.v3)
-- [API](https://segment.com/docs/libraries/http/)
-- [Specs](https://segment.com/docs/spec/)
 
 ## Usage
 
@@ -36,8 +26,8 @@ import (
 )
 
 func main() {
-    // Instantiates a client to use send messages to the segment API.
-    client := analytics.New(os.Getenv("SEGMENT_WRITE_KEY"))
+    // Instantiates a client to send messages to the dreamdata API.
+    client := analytics.New(os.Getenv("DREAMDATA_WRITE_KEY"))
 
     // Enqueues a track event that will be sent asynchronously.
     client.Enqueue(analytics.Track{

--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ package main
 import (
     "os"
 
-    "github.com/segmentio/analytics-go"
+    "github.com/dreamdata-io/analytics-go"
 )
 
 func main() {

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/segmentio/analytics-go/v3"
+	"github.com/dreamdata-io/analytics-go"
 	"github.com/segmentio/conf"
 )
 

--- a/config.go
+++ b/config.go
@@ -82,7 +82,7 @@ type Config struct {
 
 // This constant sets the default endpoint to which client instances send
 // messages if none was explictly set.
-const DefaultEndpoint = "https://localhost:8080"
+const DefaultEndpoint = "https://api.dreamdata.cloud"
 
 // This constant sets the default flush interval used by client instances if
 // none was explicitly set.

--- a/examples/track.go
+++ b/examples/track.go
@@ -3,9 +3,10 @@ package main
 import (
 	"fmt"
 
-	"github.com/segmentio/analytics-go/v3"
+	"time"
+
+	"github.com/dreamdata-io/analytics-go"
 )
-import "time"
 
 func main() {
 	client, _ := analytics.NewWithConfig("h97jamjwbh", analytics.Config{

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/segmentio/analytics-go/v3
+module github.com/dreamdata-io/analytics-go
 
 go 1.17
 


### PR DESCRIPTION
```
$ go run cmd/cli/main.go -writeKey d260dca2-2410-4d62-a2a0-4cea89a4ed84 -type track -userId test --properties '{}' -event test-event
```

See how it creates a new task in the events web tracking:

<img width="1027" alt="Screenshot 2022-04-28 at 10 57 25" src="https://user-images.githubusercontent.com/9676637/165716548-a01fddc6-9c45-457e-ab54-303539ea69f6.png">
